### PR TITLE
eslint error workaround

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,3 @@
 node_modules
+
+.eslintrc


### PR DESCRIPTION
added .eslintrc to .dockerignore, so we can keep .eslintrc in the repo for development but docker will ignore it when it is copying over the files. so effectively deleted during the build