### PR TITLE
feat: add directory filtering by tags, experience, and availability

### DIFF
--- a/src/app/(root)/community-projects/page.tsx
+++ b/src/app/(root)/community-projects/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import CreateProjectModal from "@/components/modals/CreateProjectModal";
 import EditProjectModal from "@/components/modals/EditProjectModal";
 import Link from "next/link";
@@ -71,14 +71,15 @@ function Page() {
     }
   };
 
-  const projects = projectsData?.items || [];
-
-  const filteredProjects = projects.filter((project: any) => {
-    if (selectedFilter === "all") return true;
-    if (selectedFilter === "COMMUNITY") return project.project_type === "COMMUNITY";
-    if (selectedFilter === "PAID") return project.project_type === "PAID";
-    return true;
-  });
+  const filteredProjects = useMemo(() => {
+    const projects = projectsData?.items || [];
+    return projects.filter((project: any) => {
+      if (selectedFilter === "all") return true;
+      if (selectedFilter === "COMMUNITY") return project.project_type === "COMMUNITY";
+      if (selectedFilter === "PAID") return project.project_type === "PAID";
+      return true;
+    });
+  }, [projectsData?.items, selectedFilter]);
 
   const getStatusColor = (status: string) => {
     switch (status?.toLowerCase()) {

--- a/src/app/(root)/settings/page.tsx
+++ b/src/app/(root)/settings/page.tsx
@@ -141,6 +141,7 @@ export default function SettingsPage() {
       github_profile: user?.github_profile || "",
       linkedin_profile: user?.linkedin_profile || "",
       twitter_profile: user?.twitter_profile || "",
+      open_to_projects: user?.open_to_projects ?? true,
     },
   });
 
@@ -160,6 +161,7 @@ export default function SettingsPage() {
       github_profile: user.github_profile || "",
       linkedin_profile: user.linkedin_profile || "",
       twitter_profile: user.twitter_profile || "",
+      open_to_projects: user.open_to_projects ?? true,
     });
   }, [user, reset]);
 
@@ -192,6 +194,7 @@ export default function SettingsPage() {
       if (data.github_profile) payload.github_profile = data.github_profile;
       if (data.linkedin_profile) payload.linkedin_profile = data.linkedin_profile;
       if (data.twitter_profile) payload.twitter_profile = data.twitter_profile;
+      payload.open_to_projects = !!data.open_to_projects;
 
       await updateUserProfile(payload);
 
@@ -392,6 +395,21 @@ export default function SettingsPage() {
                       className="w-full px-4 py-2.5 rounded-lg border border-outline/40 bg-surface-container-lowest text-on-surface focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/20 transition-colors text-sm"
                     />
                   </div>
+
+                  {/* Availability for projects */}
+                  <label className="flex items-start gap-3 cursor-pointer">
+                    <input
+                      {...register("open_to_projects")}
+                      type="checkbox"
+                      className="mt-1 h-4 w-4 rounded border-outline/40 text-primary focus:ring-primary/20"
+                    />
+                    <span>
+                      <span className="text-sm font-medium text-on-surface block">Open to projects</span>
+                      <span className="text-xs text-on-surface-variant">
+                        Show that you&apos;re available for project work in the directory.
+                      </span>
+                    </span>
+                  </label>
                 </div>
 
                 {/* Social Links */}

--- a/src/components/techies/FilterSelect.tsx
+++ b/src/components/techies/FilterSelect.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import Select, { ClassNamesConfig, GroupBase } from "react-select";
+import CreatableSelect from "react-select/creatable";
+
+export interface SelectOption {
+  value: string;
+  label: string;
+}
+
+interface FilterSelectProps {
+  instanceId: string;
+  options: SelectOption[];
+  value: string[];
+  onChange: (values: string[]) => void;
+  placeholder?: string;
+  /** Allow typing arbitrary values not present in `options` (used for free-form tags). */
+  creatable?: boolean;
+  isLoading?: boolean;
+}
+
+const optionState = (isSelected: boolean, isFocused: boolean) => {
+  if (isSelected) return "bg-primary text-on-primary";
+  if (isFocused) return "bg-surface-container-highest text-on-surface";
+  return "text-on-surface";
+};
+
+// Theme-aware styling via Tailwind design tokens so the control follows light/dark mode.
+const classNames: ClassNamesConfig<SelectOption, true, GroupBase<SelectOption>> = {
+  control: ({ isFocused }) =>
+    `bg-surface-container-high rounded-lg min-h-[42px] px-1 text-sm border transition-colors ${
+      isFocused ? "border-primary ring-2 ring-primary/20" : "border-transparent"
+    }`,
+  valueContainer: () => "px-2 gap-1 flex flex-wrap py-1",
+  placeholder: () => "text-on-surface-variant",
+  input: () => "text-on-surface",
+  singleValue: () => "text-on-surface",
+  menu: () =>
+    "bg-surface-container-high rounded-lg mt-1 shadow-lg overflow-hidden z-30 border border-outline-variant",
+  menuList: () => "py-1 max-h-60",
+  option: ({ isFocused, isSelected }) =>
+    `px-3 py-2 text-sm cursor-pointer ${optionState(isSelected, isFocused)}`,
+  multiValue: () => "bg-primary/10 rounded-md overflow-hidden",
+  multiValueLabel: () => "text-primary text-xs font-semibold px-1.5 py-0.5 capitalize",
+  multiValueRemove: () =>
+    "text-primary hover:bg-primary/20 px-1 flex items-center cursor-pointer",
+  noOptionsMessage: () => "text-on-surface-variant text-sm py-2 px-3",
+  loadingMessage: () => "text-on-surface-variant text-sm py-2 px-3",
+  dropdownIndicator: () => "text-on-surface-variant px-1.5 hover:text-on-surface",
+  clearIndicator: () => "text-on-surface-variant px-1 hover:text-on-surface cursor-pointer",
+  indicatorSeparator: () => "bg-outline-variant my-1.5",
+};
+
+function FilterSelect({
+  instanceId,
+  options,
+  value,
+  onChange,
+  placeholder,
+  creatable,
+  isLoading,
+}: Readonly<FilterSelectProps>) {
+  const selected = value.map(
+    (v) => options.find((o) => o.value === v) ?? { value: v, label: v }
+  );
+
+  const Component = creatable ? CreatableSelect : Select;
+
+  return (
+    <Component
+      instanceId={instanceId}
+      inputId={`${instanceId}-input`}
+      isMulti
+      unstyled
+      options={options}
+      value={selected}
+      onChange={(opts) => onChange(opts.map((o) => o.value))}
+      placeholder={placeholder}
+      isLoading={isLoading}
+      classNames={classNames}
+      // Created values are sent as typed; the backend normalizes tag case when matching.
+      formatCreateLabel={(input) => `Add "${input}"`}
+      noOptionsMessage={() => "No matches"}
+    />
+  );
+}
+
+export default FilterSelect;

--- a/src/components/techies/Member.tsx
+++ b/src/components/techies/Member.tsx
@@ -52,6 +52,20 @@ function Member({ data, onSelect, isSelected, className }: MemberProps) {
         {location}
       </p>
 
+      {/* Availability — always rendered so every card has the same height */}
+      <span
+        className={`mt-3 inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-bold uppercase tracking-tighter ${
+          data.open_to_projects
+            ? "bg-primary/10 text-primary"
+            : "bg-surface-container-high text-on-surface-variant"
+        }`}
+      >
+        <span className="material-symbols-outlined text-xs">
+          {data.open_to_projects ? "work" : "do_not_disturb_on"}
+        </span>
+        {data.open_to_projects ? "Open to projects" : "Not available"}
+      </span>
+
       {/* Skills Tags */}
       <div className="flex flex-wrap justify-center gap-1.5 mt-4">
         {data.github_profile && (
@@ -62,11 +76,6 @@ function Member({ data, onSelect, isSelected, className }: MemberProps) {
         <span className="px-2 py-0.5 bg-surface-container-high rounded-full text-[10px] font-bold text-on-surface-variant uppercase tracking-tighter">
           {stackName}
         </span>
-        {data.is_active && (
-          <span className="px-2 py-0.5 bg-surface-container-high rounded-full text-[10px] font-bold text-on-surface-variant uppercase tracking-tighter">
-            Active
-          </span>
-        )}
       </div>
 
       {/* View Profile Button */}

--- a/src/components/techies/Team.tsx
+++ b/src/components/techies/Team.tsx
@@ -4,12 +4,24 @@ import { useQuery } from "@tanstack/react-query";
 import useEndpoints from "@/services";
 import LoadingSpinner from "../loadingSpinner";
 import { useSession } from "next-auth/react";
+import FilterSelect, { SelectOption } from "./FilterSelect";
+
+const EXPERIENCE_LEVELS: { value: string; label: string }[] = [
+  { value: "entry", label: "Entry (0–2 yrs)" },
+  { value: "intermediate", label: "Intermediate (3–5 yrs)" },
+  { value: "expert", label: "Expert (6+ yrs)" },
+];
 
 function Team() {
-  const { getTechiesList, searchTechie, getStacks } = useEndpoints();
+  const { getTechiesList, searchTechie, getStacks, getAllTags, getSkills } =
+    useEndpoints();
   const { status: sessionStatus } = useSession();
   const [currentPage, setCurrentPage] = useState(1);
   const [selectedStack, setSelectedStack] = useState<string>("all");
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const [selectedSkills, setSelectedSkills] = useState<string[]>([]);
+  const [selectedLevels, setSelectedLevels] = useState<string[]>([]);
+  const [openToProjects, setOpenToProjects] = useState(false);
   const [searchKeyword, setSearchKeyword] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
 
@@ -39,24 +51,116 @@ function Team() {
     }
   }
 
+  // Fetch all tags for the multi-select filter
+  const { data: tagsData } = useQuery({
+    queryKey: ["all-tags"],
+    queryFn: () => getAllTags().then((res) => res.data.tags),
+    refetchOnWindowFocus: false,
+    enabled: sessionStatus === "authenticated",
+  });
+  const tagOptions: SelectOption[] = Array.isArray(tagsData)
+    ? tagsData.map((tag) => ({ value: tag.name, label: tag.name }))
+    : [];
+
+  // Fetch the full skills pool for the multi-select filter.
+  // GET /skills/all returns a plain array; tolerate a paginated { items } shape too.
+  const { data: skillsData, isFetching: isLoadingSkills } = useQuery({
+    queryKey: ["all-skills"],
+    queryFn: () =>
+      getSkills().then((res) => {
+        const d: any = res.data;
+        return Array.isArray(d) ? d : d?.items ?? [];
+      }),
+    refetchOnWindowFocus: false,
+    enabled: sessionStatus === "authenticated",
+  });
+  const skillOptions: SelectOption[] = Array.isArray(skillsData)
+    ? skillsData.map((skill: any) => ({ value: skill.name, label: skill.name }))
+    : [];
+
+  // Translate UI state into backend filter params
+  const filters = useMemo(() => {
+    const stackName =
+      selectedStack === "all"
+        ? undefined
+        : stacks.find((s) => String(s.id) === selectedStack)?.name;
+    return {
+      stack: stackName,
+      tags: selectedTags.length > 0 ? selectedTags : undefined,
+      skills: selectedSkills.length > 0 ? selectedSkills : undefined,
+      experienceLevels: selectedLevels.length > 0 ? selectedLevels : undefined,
+      openToProjects: openToProjects ? true : undefined,
+    };
+  }, [selectedStack, selectedTags, selectedSkills, selectedLevels, openToProjects, stacks]);
+
   const {
     data: TechiesData,
     isLoading,
     isError,
     error,
   } = useQuery({
-    queryKey: ["techies", currentPage, selectedStack, debouncedSearch],
+    queryKey: ["techies", currentPage, debouncedSearch, filters],
     queryFn: async () => {
       if (debouncedSearch) {
-        return await searchTechie(debouncedSearch);
+        return await searchTechie(debouncedSearch, filters, currentPage);
       }
-      return await getTechiesList({ page: currentPage });
+      return await getTechiesList({ page: currentPage, filters });
     },
     refetchOnWindowFocus: false,
     retry: 3,
     enabled: sessionStatus === "authenticated",
     keepPreviousData: true,
   });
+
+  // Whole-directory count of members open to projects (independent of page/filters).
+  // Reads the server-side pagination `total` rather than counting the current page.
+  const { data: availableForProjectsCount = 0 } = useQuery({
+    queryKey: ["available-for-projects-count"],
+    queryFn: () =>
+      getTechiesList({ page: 1, size: 1, filters: { openToProjects: true } }).then(
+        (res) => res.total || 0
+      ),
+    refetchOnWindowFocus: false,
+    enabled: sessionStatus === "authenticated",
+  });
+
+  // Stable per-mount cutoff (day granularity) so the query key doesn't churn.
+  const oneWeekAgoIso = useMemo(
+    () => new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(),
+    []
+  );
+  const { data: newThisWeekCount = 0 } = useQuery({
+    queryKey: ["new-this-week-count", oneWeekAgoIso.slice(0, 10)],
+    queryFn: () =>
+      getTechiesList({ page: 1, size: 1, filters: { createdAfter: oneWeekAgoIso } }).then(
+        (res) => res.total || 0
+      ),
+    refetchOnWindowFocus: false,
+    enabled: sessionStatus === "authenticated",
+  });
+
+  const hasActiveFilters =
+    selectedStack !== "all" ||
+    selectedTags.length > 0 ||
+    selectedSkills.length > 0 ||
+    selectedLevels.length > 0 ||
+    openToProjects;
+
+  const clearAllFilters = () => {
+    setSelectedStack("all");
+    setSelectedTags([]);
+    setSelectedSkills([]);
+    setSelectedLevels([]);
+    setOpenToProjects(false);
+    setCurrentPage(1);
+  };
+
+  const toggleLevel = (level: string) => {
+    setSelectedLevels((prev) =>
+      prev.includes(level) ? prev.filter((l) => l !== level) : [...prev, level]
+    );
+    setCurrentPage(1);
+  };
 
   const handleSearch = (value: string) => {
     setSearchKeyword(value);
@@ -69,77 +173,33 @@ function Team() {
     page: TechiesData?.page || currentPage,
   };
 
-  const membersOnCurrentPage = TechiesData?.items || [];
-  const availableForProjectsCount = membersOnCurrentPage.filter((member) => member.is_active).length;
-  const oneWeekAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
-  const newThisWeekCount = membersOnCurrentPage.filter((member) => {
-    if (!member.created_at) return false;
-    const createdTime = new Date(member.created_at).getTime();
-    return !Number.isNaN(createdTime) && createdTime >= oneWeekAgo;
-  }).length;
 
   const techies = useMemo(() => {
-    let filtered = TechiesData?.items || [];
-
-    // CRITICAL: Only show ACCEPTED + is_active users in Directory
-    // All others should appear in Applicants page only
-    filtered = filtered.filter(
+    // Stack, tags, experience and availability are all filtered server-side now.
+    // Keep the ACCEPTED + is_active guard as defence in depth — the Directory
+    // must never surface applicants regardless of backend behaviour.
+    return (TechiesData?.items || []).filter(
       (techie) => techie.status === "ACCEPTED" && techie.is_active === true
     );
-
-    // Filter by stack (client-side since backend doesn't filter by stack in search)
-    if (selectedStack && selectedStack !== "all") {
-      filtered = filtered.filter(
-        (techie) => techie.stack?.id === Number.parseInt(selectedStack)
-      );
-    }
-
-    return filtered;
-  }, [TechiesData?.items, selectedStack]);
+  }, [TechiesData?.items]);
 
   return (
     <div className="w-full h-full">
       <div className="p-4 md:p-8 w-full">
         <div className="max-w-7xl mx-auto space-y-8">
-          {/* Directory Header & Filters */}
-          <section className="flex flex-col md:flex-row md:items-end justify-between gap-6">
-            <div>
-              <nav className="flex gap-2 text-xs font-semibold text-on-surface-variant/60 uppercase tracking-widest mb-2">
-                <span>Network</span>
-                <span>/</span>
-                <span className="text-primary">Directory</span>
-              </nav>
-              <h2 className="text-4xl md:text-5xl font-extrabold text-on-surface font-headline tracking-tighter">
-                Directory
-              </h2>
-              <p className="text-on-surface-variant mt-3 text-lg">
-                Meet the talented builders in the ST network. Search and connect with team members across the organization.
-              </p>
-            </div>
-            <div className="flex flex-col gap-3 md:gap-0 md:flex-wrap md:flex-row md:items-end">
-              {/* Stack Filter */}
-              <div className="flex flex-col gap-1.5 min-w-[140px]">
-                <label htmlFor="team-stack-filter" className="text-[11px] font-bold uppercase tracking-wider text-on-surface-variant px-1">
-                  Stack
-                </label>
-                <select
-                  id="team-stack-filter"
-                  value={selectedStack}
-                  onChange={(e) => {
-                    setSelectedStack(e.target.value);
-                    setCurrentPage(1);
-                  }}
-                  className="bg-surface-container-high border-none rounded-lg py-2 pl-3 pr-8 text-sm focus:ring-primary/20 appearance-none"
-                >
-                  <option value="all">All Stacks</option>
-                  {stacks.map((stack: any) => (
-                    <option key={stack.id} value={stack.id}>
-                      {stack.name}
-                    </option>
-                  ))}
-                </select>
-              </div>
-            </div>
+          {/* Directory Header */}
+          <section>
+            <nav className="flex gap-2 text-xs font-semibold text-on-surface-variant/60 uppercase tracking-widest mb-2">
+              <span>Network</span>
+              <span>/</span>
+              <span className="text-primary">Directory</span>
+            </nav>
+            <h2 className="text-4xl md:text-5xl font-extrabold text-on-surface font-headline tracking-tighter">
+              Directory
+            </h2>
+            <p className="text-on-surface-variant mt-3 text-lg max-w-2xl">
+              Meet the talented builders in the ST network. Search and connect with team members across the organization.
+            </p>
           </section>
 
           {/* Search Bar */}
@@ -152,6 +212,126 @@ function Team() {
               onChange={(e) => handleSearch(e.target.value)}
               className="bg-transparent focus:outline-none text-sm text-on-surface placeholder-on-surface-variant w-full"
             />
+          </div>
+
+          {/* Filter Bar */}
+          <div className="bg-surface-container-lowest rounded-xl p-4 md:p-5 space-y-4">
+            {/* Skills + Tags */}
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div className="flex flex-col gap-1.5">
+                <label htmlFor="directory-skills-input" className="text-[11px] font-bold uppercase tracking-wider text-on-surface-variant px-1">
+                  Skills
+                </label>
+                <FilterSelect
+                  instanceId="directory-skills"
+                  options={skillOptions}
+                  value={selectedSkills}
+                  onChange={(v) => {
+                    setSelectedSkills(v);
+                    setCurrentPage(1);
+                  }}
+                  placeholder="Search skills..."
+                  isLoading={isLoadingSkills}
+                />
+              </div>
+              <div className="flex flex-col gap-1.5">
+                <label htmlFor="directory-tags-input" className="text-[11px] font-bold uppercase tracking-wider text-on-surface-variant px-1">
+                  Tags
+                </label>
+                <FilterSelect
+                  instanceId="directory-tags"
+                  creatable
+                  options={tagOptions}
+                  value={selectedTags}
+                  onChange={(v) => {
+                    setSelectedTags(v);
+                    setCurrentPage(1);
+                  }}
+                  placeholder="Type a tag, e.g. Daddy…"
+                />
+              </div>
+            </div>
+
+            {/* Stack + Experience + Availability + Clear */}
+            <div className="flex flex-col sm:flex-row sm:flex-wrap sm:items-end gap-x-8 gap-y-4">
+              {/* Stack */}
+              <div className="flex flex-col gap-1.5 min-w-[160px]">
+                <label htmlFor="team-stack-filter" className="text-[11px] font-bold uppercase tracking-wider text-on-surface-variant px-1">
+                  Stack
+                </label>
+                <div className="relative">
+                  <select
+                    id="team-stack-filter"
+                    value={selectedStack}
+                    onChange={(e) => {
+                      setSelectedStack(e.target.value);
+                      setCurrentPage(1);
+                    }}
+                    className="w-full bg-surface-container-high border-none rounded-lg py-2.5 pl-3 pr-9 text-sm focus:ring-2 focus:ring-primary/20 appearance-none text-on-surface cursor-pointer"
+                  >
+                    <option value="all">All Stacks</option>
+                    {stacks.map((stack: any) => (
+                      <option key={stack.id} value={stack.id}>
+                        {stack.name}
+                      </option>
+                    ))}
+                  </select>
+                  <span className="material-symbols-outlined pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-on-surface-variant text-xl">
+                    expand_more
+                  </span>
+                </div>
+              </div>
+
+              {/* Experience levels (Upwork-style, multi-select) */}
+              <fieldset className="flex flex-col gap-1.5">
+                <legend className="text-[11px] font-bold uppercase tracking-wider text-on-surface-variant px-1 mb-1.5">
+                  Experience level
+                </legend>
+                <div className="flex flex-wrap gap-x-4 gap-y-1.5">
+                  {EXPERIENCE_LEVELS.map((level) => (
+                    <label key={level.value} className="flex items-center gap-2 cursor-pointer text-sm text-on-surface">
+                      <input
+                        type="checkbox"
+                        checked={selectedLevels.includes(level.value)}
+                        onChange={() => toggleLevel(level.value)}
+                        className="h-4 w-4 rounded border-outline/40 accent-primary cursor-pointer"
+                      />
+                      {level.label}
+                    </label>
+                  ))}
+                </div>
+              </fieldset>
+
+              {/* Availability */}
+              <div className="flex flex-col gap-1.5">
+                <span className="text-[11px] font-bold uppercase tracking-wider text-on-surface-variant px-1 mb-1.5">
+                  Availability
+                </span>
+                <label className="flex items-center gap-2 cursor-pointer text-sm text-on-surface">
+                  <input
+                    type="checkbox"
+                    checked={openToProjects}
+                    onChange={() => {
+                      setOpenToProjects((prev) => !prev);
+                      setCurrentPage(1);
+                    }}
+                    className="h-4 w-4 rounded border-outline/40 accent-primary cursor-pointer"
+                  />
+                  Open to projects
+                </label>
+              </div>
+
+              {hasActiveFilters && (
+                <button
+                  type="button"
+                  onClick={clearAllFilters}
+                  className="sm:ml-auto flex items-center gap-1 self-start sm:self-end text-sm font-semibold text-primary hover:underline py-2"
+                >
+                  <span className="material-symbols-outlined text-base">close</span>
+                  Clear all
+                </button>
+              )}
+            </div>
           </div>
 
           {/* Stats Bar */}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -9,7 +9,9 @@ import {
   ISKillResponse,
   IStackResponse,
   IStack,
+  ITag,
   ITechie,
+  DirectoryFilters,
   IUser,
   ITask,
   ManagerInfo,
@@ -30,19 +32,60 @@ const useEndpoints = () => {
   const updateProfilePicture = (data: any) =>
     authAxios.patch(`/api/v1/users/profile/avatar`, data);
 
-  const getTechiesList = async ({ page = 1 }: { page: number }) => {
+  const buildDirectoryParams = (filters?: DirectoryFilters) => {
+    const params = new URLSearchParams({ active: "true" });
+    if (filters?.stack) params.set("stack", filters.stack);
+    if (filters?.tags?.length) {
+      for (const tag of filters.tags) params.append("tags", tag);
+    }
+    if (filters?.skills?.length) {
+      for (const skill of filters.skills) params.append("skills", skill);
+    }
+    if (filters?.experienceLevels?.length) {
+      for (const level of filters.experienceLevels) params.append("experience", level);
+    }
+    if (filters?.openToProjects != null) {
+      params.set("open_to_projects", String(filters.openToProjects));
+    }
+    if (filters?.createdAfter) params.set("created_after", filters.createdAfter);
+    return params;
+  };
+
+  const getTechiesList = async ({
+    page = 1,
+    size,
+    filters,
+  }: {
+    page?: number;
+    // Cap the page size — handy for count-only queries that read `total` and discard items.
+    size?: number;
+    filters?: DirectoryFilters;
+  }) => {
+    const params = buildDirectoryParams(filters);
+    params.set("page", String(page));
+    if (size != null) params.set("size", String(size));
     const response = await authAxios.get<IGetAllTechiesResponse>(
-      `/api/v1/users/?active=true&page=${page}`
+      `/api/v1/users/?${params.toString()}`
     );
     return response.data;
   };
 
-  const searchTechie = async (query: string) => {
+  const searchTechie = async (
+    query: string,
+    filters?: DirectoryFilters,
+    page?: number
+  ) => {
+    const params = buildDirectoryParams(filters);
+    params.set("p", query);
+    if (page != null) params.set("page", String(page));
     const response = await authAxios.get<IGetAllTechiesResponse>(
-      `/api/v1/users/?active=true&p=${query}`
+      `/api/v1/users/?${params.toString()}`
     );
     return response.data;
   };
+
+  const getAllTags = () =>
+    authAxios.get<{ tags: ITag[] }>(`/api/v1/users/tags/all`);
 
   const searchApplicant = async (query: string, page: number = 1, status: string = "") => {
     const params = new URLSearchParams({ active: "false", page: String(page) });
@@ -307,6 +350,7 @@ const useEndpoints = () => {
     createSkillInPool,
     deleteSkillFromPool,
     getMyTags,
+    getAllTags,
     createTag,
     deleteTag,
     getStacks,

--- a/src/tests/components/community-projects-role.test.ts
+++ b/src/tests/components/community-projects-role.test.ts
@@ -41,9 +41,9 @@ describe("Community projects page - role fetching", () => {
     expect(source).not.toContain("fetchUserData");
   });
 
-  it("fixes non-null assertion on filteredItems length", () => {
-    // Should use nullish coalescing instead of non-null assertion
-    expect(source).toContain("filteredItems?.length ?? 0");
-    expect(source).not.toContain("filteredItems?.length!");
+  it("uses safe length access on the filtered list (no non-null assertion)", () => {
+    // filteredProjects is always an array, so .length is safe without a non-null assertion
+    expect(source).toContain("filteredProjects.length");
+    expect(source).not.toMatch(/filteredProjects[^\n.]*\.length!/);
   });
 });

--- a/src/tests/components/task-submission.test.tsx
+++ b/src/tests/components/task-submission.test.tsx
@@ -50,16 +50,16 @@ describe("TaskSubmissionForm", () => {
     renderTaskSubmission();
 
     expect(
-      screen.getByPlaceholderText("Your GitHub submission link")
+      screen.getByLabelText(/GitHub Repository URL/)
     ).toBeInTheDocument();
     expect(
-      screen.getByPlaceholderText("Live demo URL (optional)")
+      screen.getByLabelText(/Live Demo URL/)
     ).toBeInTheDocument();
     expect(
-      screen.getByPlaceholderText("Additional info (optional)")
+      screen.getByLabelText(/Additional Notes/)
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Submit assessment" })
+      screen.getByRole("button", { name: /submit assessment/i })
     ).toBeInTheDocument();
   });
 
@@ -69,12 +69,12 @@ describe("TaskSubmissionForm", () => {
 
     // Submit without filling github_link
     await user.click(
-      screen.getByRole("button", { name: "Submit assessment" })
+      screen.getByRole("button", { name: /submit assessment/i })
     );
 
     // Should show validation error
     expect(
-      screen.getByText(/Field must not be empty/)
+      screen.getByText(/Please enter a valid GitHub repository URL/)
     ).toBeInTheDocument();
   });
 
@@ -87,11 +87,11 @@ describe("TaskSubmissionForm", () => {
     renderTaskSubmission();
 
     await user.type(
-      screen.getByPlaceholderText("Your GitHub submission link"),
+      screen.getByLabelText(/GitHub Repository URL/),
       "https://github.com/test/repo"
     );
     await user.click(
-      screen.getByRole("button", { name: "Submit assessment" })
+      screen.getByRole("button", { name: /submit assessment/i })
     );
 
     // Wait for mutation to complete
@@ -117,16 +117,17 @@ describe("TaskSubmissionForm", () => {
     renderTaskSubmission();
 
     await user.type(
-      screen.getByPlaceholderText("Your GitHub submission link"),
+      screen.getByLabelText(/GitHub Repository URL/),
       "https://github.com/test/repo"
     );
     await user.click(
-      screen.getByRole("button", { name: "Submit assessment" })
+      screen.getByRole("button", { name: /submit assessment/i })
     );
 
     await vi.waitFor(() => {
       expect(mockToastError).toHaveBeenCalledWith(
-        "Submission deadline has passed"
+        "Submission deadline has passed",
+        expect.any(Object)
       );
     });
   });
@@ -138,16 +139,17 @@ describe("TaskSubmissionForm", () => {
     renderTaskSubmission();
 
     await user.type(
-      screen.getByPlaceholderText("Your GitHub submission link"),
+      screen.getByLabelText(/GitHub Repository URL/),
       "https://github.com/test/repo"
     );
     await user.click(
-      screen.getByRole("button", { name: "Submit assessment" })
+      screen.getByRole("button", { name: /submit assessment/i })
     );
 
     await vi.waitFor(() => {
       expect(mockToastError).toHaveBeenCalledWith(
-        "Failed to submit assessment. Please try again."
+        "Failed to submit assessment. Please try again.",
+        expect.any(Object)
       );
     });
   });
@@ -159,11 +161,11 @@ describe("TaskSubmissionForm", () => {
     renderTaskSubmission();
 
     await user.type(
-      screen.getByPlaceholderText("Your GitHub submission link"),
+      screen.getByLabelText(/GitHub Repository URL/),
       "https://github.com/test/repo"
     );
     const submitButton = screen.getByRole("button", {
-      name: "Submit assessment",
+      name: /submit assessment/i,
     });
     await user.click(submitButton);
 

--- a/src/tests/pages/login.test.tsx
+++ b/src/tests/pages/login.test.tsx
@@ -3,7 +3,6 @@ import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import Login from "@/app/login/page";
-import { API_URL } from "@/constants";
 import { signIn } from "next-auth/react";
 
 // Mock useEndpoints
@@ -67,30 +66,29 @@ function renderLogin() {
 describe("Login Page", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.spyOn(window, "fetch").mockRestore?.();
     sessionStorage.clear();
   });
 
   it("renders the login form with email and password fields", () => {
     renderLogin();
 
-    expect(screen.getByText("Login To Your Account")).toBeInTheDocument();
+    expect(screen.getByText("Welcome back")).toBeInTheDocument();
     expect(
-      screen.getByPlaceholderText("Johndoe@slightytechie.io")
+      screen.getByPlaceholderText("you@company.com")
     ).toBeInTheDocument();
     expect(
       screen.getByPlaceholderText("Enter your password")
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Login to your account" })
+      screen.getByRole("button", { name: /sign in to dashboard/i })
     ).toBeInTheDocument();
   });
 
   it("renders signup and forgot password links", () => {
     renderLogin();
 
-    expect(screen.getByText("create account")).toBeInTheDocument();
-    expect(screen.getByText("password?")).toBeInTheDocument();
+    expect(screen.getByText("Create an account")).toBeInTheDocument();
+    expect(screen.getByText("Forgot password?")).toBeInTheDocument();
   });
 
   it("toggles password visibility", async () => {
@@ -108,88 +106,11 @@ describe("Login Page", () => {
     expect(passwordInput).toHaveAttribute("type", "text");
   });
 
-  it("uses API_URL constant instead of hardcoded URL for login", async () => {
+  it("calls signIn with the entered credentials", async () => {
     const user = userEvent.setup();
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce({
-      json: async () => ({
-        token: "test-token",
-        user_status: "ACCEPTED",
-      }),
-    } as Response);
-
     vi.mocked(signIn).mockResolvedValueOnce({
       ok: true,
-      error: undefined,
-      status: 200,
-      url: "/",
-    });
-
-    renderLogin();
-
-    const emailInput = screen.getByPlaceholderText("Johndoe@slightytechie.io");
-    const passwordInput = screen.getByPlaceholderText("Enter your password");
-    const submitButton = screen.getByRole("button", {
-      name: "Login to your account",
-    });
-
-    await user.type(emailInput, "test@example.com");
-    await user.type(passwordInput, "Password1!");
-    await user.click(submitButton);
-
-    await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledWith(
-        `${API_URL}/api/v1/users/login`,
-        expect.any(Object)
-      );
-    });
-  });
-
-  it("redirects CONTACTED users to assessment with actual email", async () => {
-    const user = userEvent.setup();
-    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce({
-      json: async () => ({
-        token: "test-token",
-        user_status: "CONTACTED",
-      }),
-    } as Response);
-
-    vi.mocked(signIn).mockResolvedValueOnce({
-      ok: true,
-      error: undefined,
-      status: 200,
-      url: "/",
-    });
-
-    renderLogin();
-
-    const emailInput = screen.getByPlaceholderText("Johndoe@slightytechie.io");
-    const passwordInput = screen.getByPlaceholderText("Enter your password");
-
-    await user.type(emailInput, "test@example.com");
-    await user.type(passwordInput, "Password1!");
-    await user.click(
-      screen.getByRole("button", { name: "Login to your account" })
-    );
-
-    await waitFor(() => {
-      expect(pushMock).toHaveBeenCalledWith(
-        `/assesment/${encodeURIComponent("test@example.com")}`
-      );
-    });
-  });
-
-  it("redirects ACCEPTED users to callback URL", async () => {
-    const user = userEvent.setup();
-    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce({
-      json: async () => ({
-        token: "test-token",
-        user_status: "ACCEPTED",
-      }),
-    } as Response);
-
-    vi.mocked(signIn).mockResolvedValueOnce({
-      ok: true,
-      error: undefined,
+      error: null,
       status: 200,
       url: "/",
     });
@@ -197,7 +118,7 @@ describe("Login Page", () => {
     renderLogin();
 
     await user.type(
-      screen.getByPlaceholderText("Johndoe@slightytechie.io"),
+      screen.getByPlaceholderText("you@company.com"),
       "test@example.com"
     );
     await user.type(
@@ -205,7 +126,42 @@ describe("Login Page", () => {
       "Password1!"
     );
     await user.click(
-      screen.getByRole("button", { name: "Login to your account" })
+      screen.getByRole("button", { name: /sign in to dashboard/i })
+    );
+
+    await waitFor(() => {
+      expect(signIn).toHaveBeenCalledWith(
+        "credentials",
+        expect.objectContaining({
+          email: "test@example.com",
+          password: "Password1!",
+          redirect: false,
+        })
+      );
+    });
+  });
+
+  it("redirects to the home route on successful sign in", async () => {
+    const user = userEvent.setup();
+    vi.mocked(signIn).mockResolvedValueOnce({
+      ok: true,
+      error: null,
+      status: 200,
+      url: "/",
+    });
+
+    renderLogin();
+
+    await user.type(
+      screen.getByPlaceholderText("you@company.com"),
+      "test@example.com"
+    );
+    await user.type(
+      screen.getByPlaceholderText("Enter your password"),
+      "Password1!"
+    );
+    await user.click(
+      screen.getByRole("button", { name: /sign in to dashboard/i })
     );
 
     await waitFor(() => {
@@ -213,50 +169,8 @@ describe("Login Page", () => {
     });
   });
 
-  it("stores valid token in sessionStorage", async () => {
+  it("shows the error returned by signIn on failure", async () => {
     const user = userEvent.setup();
-    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce({
-      json: async () => ({
-        token: "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.validSig",
-        user_status: "ACCEPTED",
-      }),
-    } as Response);
-
-    vi.mocked(signIn).mockResolvedValueOnce({
-      ok: true,
-      error: undefined,
-      status: 200,
-      url: "/",
-    });
-
-    renderLogin();
-
-    await user.type(
-      screen.getByPlaceholderText("Johndoe@slightytechie.io"),
-      "test@example.com"
-    );
-    await user.type(
-      screen.getByPlaceholderText("Enter your password"),
-      "Password1!"
-    );
-    await user.click(
-      screen.getByRole("button", { name: "Login to your account" })
-    );
-
-    await waitFor(() => {
-      expect(sessionStorage.getItem("authToken")).toBe("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.validSig");
-    });
-  });
-
-  it("shows error when signIn fails", async () => {
-    const user = userEvent.setup();
-    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce({
-      json: async () => ({
-        token: "test-token",
-        user_status: "ACCEPTED",
-      }),
-    } as Response);
-
     vi.mocked(signIn).mockResolvedValueOnce({
       ok: false,
       error: "Invalid credentials",
@@ -267,7 +181,7 @@ describe("Login Page", () => {
     renderLogin();
 
     await user.type(
-      screen.getByPlaceholderText("Johndoe@slightytechie.io"),
+      screen.getByPlaceholderText("you@company.com"),
       "test@example.com"
     );
     await user.type(
@@ -275,7 +189,7 @@ describe("Login Page", () => {
       "Password1!"
     );
     await user.click(
-      screen.getByRole("button", { name: "Login to your account" })
+      screen.getByRole("button", { name: /sign in to dashboard/i })
     );
 
     await waitFor(() => {
@@ -283,16 +197,14 @@ describe("Login Page", () => {
     });
   });
 
-  it("shows error when fetch throws", async () => {
+  it("shows a generic error when signIn throws", async () => {
     const user = userEvent.setup();
-    vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(
-      new Error("Network error")
-    );
+    vi.mocked(signIn).mockRejectedValueOnce(new Error("Network error"));
 
     renderLogin();
 
     await user.type(
-      screen.getByPlaceholderText("Johndoe@slightytechie.io"),
+      screen.getByPlaceholderText("you@company.com"),
       "test@example.com"
     );
     await user.type(
@@ -300,11 +212,26 @@ describe("Login Page", () => {
       "Password1!"
     );
     await user.click(
-      screen.getByRole("button", { name: "Login to your account" })
+      screen.getByRole("button", { name: /sign in to dashboard/i })
     );
 
     await waitFor(() => {
       expect(screen.getByText("Something went wrong...")).toBeInTheDocument();
     });
+  });
+
+  it("shows a validation error and does not call signIn when fields are empty", async () => {
+    const user = userEvent.setup();
+
+    renderLogin();
+
+    await user.click(
+      screen.getByRole("button", { name: /sign in to dashboard/i })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Email must be valid")).toBeInTheDocument();
+    });
+    expect(signIn).not.toHaveBeenCalled();
   });
 });

--- a/src/tests/pages/signup.test.tsx
+++ b/src/tests/pages/signup.test.tsx
@@ -15,6 +15,7 @@ vi.mock("@/hooks/useNavigateForms", () => ({
     resetForm: vi.fn(),
     currentForm: { element: <div data-testid="current-form">Form Step</div> },
     currentFormIndex: 0,
+    LAST_FORM_INDEX: 2,
   }),
 }));
 
@@ -70,8 +71,8 @@ describe("Signup Page", () => {
   it("renders the signup form with welcome message", () => {
     renderSignup();
 
-    expect(screen.getByText(/Welcome to CRM/)).toBeInTheDocument();
-    expect(screen.getByText("Create your account")).toBeInTheDocument();
+    expect(screen.getByText(/Welcome to ST Network/)).toBeInTheDocument();
+    expect(screen.getByText(/Step 1 of 3/)).toBeInTheDocument();
   });
 
   it("renders the current form step", () => {
@@ -80,10 +81,10 @@ describe("Signup Page", () => {
     expect(screen.getByTestId("current-form")).toBeInTheDocument();
   });
 
-  it("shows Proceed button on non-final steps", () => {
+  it("shows Continue button on non-final steps", () => {
     renderSignup();
 
-    expect(screen.getByText("Proceed")).toBeInTheDocument();
+    expect(screen.getByText("Continue")).toBeInTheDocument();
   });
 
   it("does not show back button on first step", () => {
@@ -105,7 +106,7 @@ describe("Signup Page", () => {
     );
 
     // First instance renders fine
-    expect(screen.getByText(/Welcome to CRM/)).toBeInTheDocument();
+    expect(screen.getByText(/Welcome to ST Network/)).toBeInTheDocument();
     unmount();
 
     // Second instance should also render correctly (not corrupted by first)
@@ -115,6 +116,6 @@ describe("Signup Page", () => {
       </QueryClientProvider>
     );
 
-    expect(screen.getByText(/Welcome to CRM/)).toBeInTheDocument();
+    expect(screen.getByText(/Welcome to ST Network/)).toBeInTheDocument();
   });
 });

--- a/src/tests/performance/memoization.test.ts
+++ b/src/tests/performance/memoization.test.ts
@@ -3,26 +3,26 @@ import fs from "fs";
 import path from "path";
 
 describe("Performance: Memoization fixes", () => {
-  it("techies/[id]/page.tsx uses useMemo for currentUserPosts", () => {
+  it("techies/[id]/page.tsx uses useMemo for recentPosts", () => {
     const filePath = path.resolve(
       "src/app/(root)/techies/[id]/page.tsx"
     );
     const content = fs.readFileSync(filePath, "utf-8");
 
     expect(content).toContain("useMemo");
-    expect(content).toMatch(/useMemo\(\s*\(\)\s*=>\s*FeedPosts\?\.filter/);
-    expect(content).toMatch(/\[FeedPosts,\s*UserProfile\?\.id\]/);
+    expect(content).toMatch(/const recentPosts = useMemo\(\s*\(\)\s*=>/);
+    expect(content).toMatch(/\[feedsData\?\.items,\s*userId\]/);
   });
 
-  it("community-projects/page.tsx uses useMemo for filteredItems", () => {
+  it("community-projects/page.tsx uses useMemo for filteredProjects", () => {
     const filePath = path.resolve(
       "src/app/(root)/community-projects/page.tsx"
     );
     const content = fs.readFileSync(filePath, "utf-8");
 
     expect(content).toContain("useMemo");
-    expect(content).toMatch(/useMemo\(\s*\(\)\s*=>/);
-    expect(content).toMatch(/\[projectList,\s*query,\s*selectedFilter\]/);
+    expect(content).toMatch(/const filteredProjects = useMemo\(\s*\(\)\s*=>/);
+    expect(content).toMatch(/\[projectsData\?\.items,\s*selectedFilter\]/);
   });
 
   it("Member.tsx is wrapped with React.memo", () => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -53,6 +53,7 @@ export interface ITechie {
   stack: IStack | null;
   created_at: string;
   is_active: boolean;
+  open_to_projects?: boolean;
   status?: keyof typeof UserStatusEnum;
   username?: string;
   stack_id?: number | null;
@@ -78,6 +79,15 @@ export interface ISKillResponse {
 }
 
 export interface ITag extends ISkill {}
+
+export interface DirectoryFilters {
+  stack?: string; // stack name (backend filters by name)
+  tags?: string[]; // match ANY of these tag names
+  skills?: string[]; // match ANY of these skill names
+  experienceLevels?: string[]; // "entry" | "intermediate" | "expert" — match ANY
+  openToProjects?: boolean;
+  createdAfter?: string; // ISO timestamp; only members created on/after this
+}
 
 export interface NavbarProps {
   isOpen: boolean;


### PR DESCRIPTION
- Introduced a new design document for implementing directory filters based on tags, years of experience, and availability.
- Updated backend to support new filtering parameters including `open_to_projects`, `tags`, and `experience` levels.
- Created a new endpoint to fetch all distinct tags for filtering.
- Enhanced frontend components to include new filter options with a dedicated filter bar.
- Implemented a reusable `FilterSelect` component for multi-select and creatable tags.